### PR TITLE
allow pango/cairo v0.13

### DIFF
--- a/plot.cabal
+++ b/plot.cabal
@@ -51,7 +51,7 @@ library
   Build-Depends:     base >= 4 && < 5,
                      mtl > 2, array,
                      MaybeT,
-                     pango >= 0.11.2 && < 0.13, cairo >= 0.11.1 && < 0.13,
+                     pango >= 0.11.2 && < 0.14, cairo >= 0.11.1 && < 0.14,
                      colour >= 2.2.1 && < 2.4,
                      hmatrix >= 0.10
 


### PR DESCRIPTION
v0.13 of gtk2hs generalizes many functions that used to only take `String` to now accept `String` or `Text`, so I wouldn't expect any problems with this.
