### PR TITLE
Clean up warnings, get rid of MaybeT package

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -121,3 +121,7 @@
 
 0.2.3.2:
 		* allow v0.13 of pango/cairo
+
+0.2.3.4:
+        * clean up warnings
+        * use transformers instead of MaybeT

--- a/THANKS
+++ b/THANKS
@@ -4,3 +4,4 @@
  * takano-akio pointed out bug in interaction between 
      non-default point size and legend placement/scaling
  * pacak updated for AMP for ghc 7.10
+ * pacak - clean up warnings and simplify dependencies

--- a/lib/Control/Monad/Supply.hs
+++ b/lib/Control/Monad/Supply.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Control.Monad.Supply
@@ -25,8 +26,9 @@ module Control.Monad.Supply (
                             ) where
 
 -----------------------------------------------------------------------------
+#if !(MIN_VERSION_base(4,8,0))
 import Control.Applicative
-import Control.Monad (ap)
+#endif
 import Control.Monad.Writer
 import Control.Monad.Reader
 import Control.Monad.State

--- a/lib/Graphics/Rendering/Plot/Figure/Plot/Data.hs
+++ b/lib/Graphics/Rendering/Plot/Figure/Plot/Data.hs
@@ -49,7 +49,7 @@ import qualified Data.Array.IArray as A
 import Control.Monad.State
 import Control.Monad.Reader
 import Control.Monad.Supply
-import Control.Monad.Maybe
+import Control.Monad.Trans.Maybe
 
 import Graphics.Rendering.Plot.Types
 import Graphics.Rendering.Plot.Figure.Line

--- a/lib/Graphics/Rendering/Plot/Render/Plot/Annotation.hs
+++ b/lib/Graphics/Rendering/Plot/Render/Plot/Annotation.hs
@@ -138,7 +138,7 @@ renderAnnotation xscale yscale (AnnText te (x1',y1')) = do
   _ <- renderText te TRight TTop (x1) (y1)
   cairo $ C.restore
   return ()
-renderAnnotation xscale yscale (AnnCairo r) = do
+renderAnnotation _xscale _yscale (AnnCairo r) = do
   (BoundingBox x y w h) <- get
   cairo $ do
     C.save

--- a/lib/Graphics/Rendering/Plot/Render/Plot/Data.hs
+++ b/lib/Graphics/Rendering/Plot/Render/Plot/Data.hs
@@ -46,7 +46,7 @@ import qualified Graphics.Rendering.Cairo.Matrix as CM
 
 import Control.Monad.Reader
 import Control.Monad.State
-import Control.Monad.Maybe
+import Control.Monad.Trans.Maybe
 
 import Graphics.Rendering.Plot.Types
 

--- a/lib/Graphics/Rendering/Plot/Render/Plot/Legend.hs
+++ b/lib/Graphics/Rendering/Plot/Render/Plot/Legend.hs
@@ -255,7 +255,7 @@ renderLegendEntries x y wa ha w h to ls = do
   return ()
 
 renderLegendEntry :: Double -> Double -> Double -> Double -> TextOptions -> (Double,Double) -> (SeriesLabel,Decoration) -> Render (Double,Double)
-renderLegendEntry wa ha w h to (x,y) (l,d) = do
+renderLegendEntry wa ha _w h to (x,y) (l,d) = do
   renderLegendSample x y legendSampleWidth h d
   pc <- asks _pangocontext
   cairo $ do

--- a/lib/Graphics/Rendering/Plot/Render/Types.hs
+++ b/lib/Graphics/Rendering/Plot/Render/Types.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving, CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Graphics.Rendering.Plot.Render.Types
@@ -35,7 +35,9 @@ import qualified Graphics.Rendering.Cairo as C
 import qualified Graphics.Rendering.Cairo.Matrix as CM
 import qualified Graphics.Rendering.Pango as P
 
+#if !(MIN_VERSION_base(4,8,0))
 import Control.Applicative
+#endif
 import Control.Monad.Reader
 import Control.Monad.State
 --import Control.Monad.Trans

--- a/lib/Graphics/Rendering/Plot/Types.hs
+++ b/lib/Graphics/Rendering/Plot/Types.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Graphics.Rendering.Plot.Types
@@ -32,7 +33,9 @@ import qualified Data.Array.IArray as A
 import qualified Graphics.Rendering.Cairo as C
 import qualified Graphics.Rendering.Pango as P
 
+#if !(MIN_VERSION_base(4,8,0))
 import Control.Applicative
+#endif
 import Control.Monad.State
 import Control.Monad.Reader
 

--- a/plot.cabal
+++ b/plot.cabal
@@ -50,7 +50,7 @@ library
 
   Build-Depends:     base >= 4 && < 5,
                      mtl > 2, array,
-                     MaybeT,
+                     transformers > 0.2 && < 0.5,
                      pango >= 0.11.2 && < 0.14, cairo >= 0.11.1 && < 0.14,
                      colour >= 2.2.1 && < 2.4,
                      hmatrix >= 0.10

--- a/plot.cabal
+++ b/plot.cabal
@@ -1,5 +1,5 @@
 Name:                plot
-Version:             0.2.3.3
+Version:             0.2.3.4
 License:             BSD3
 License-file:        LICENSE
 Copyright:           (c) A.V.H. McPhail 2010, 2012, 2013, 2014


### PR DESCRIPTION
Removed some leftovers from AMP update and some unused variables. Also replaced MaybeT from MaybeT package (last updated a while ago) with MaybeT from transformers. plot already indirectly depends on transformers (via mtl) so it won't add any extra dependencies.

I've checked that everything compiles on 7.10 and 7.8.