### PR TITLE
Fix build against mtl-2.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist
+dist-newstyle
 docs
 wiki
 TAGS

--- a/lib/Graphics/Rendering/Plot/Figure/Plot/Axis.hs
+++ b/lib/Graphics/Rendering/Plot/Figure/Plot/Axis.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Graphics.Rendering.Plot.Figure.Plot.Axis
@@ -33,6 +34,9 @@ import Data.Maybe (fromMaybe)
 
 import Control.Monad.State
 import Control.Monad.Reader
+#if MIN_VERSION_mtl(2,3,0)
+import Control.Monad
+#endif
 
 import Graphics.Rendering.Plot.Types
 import Graphics.Rendering.Plot.Defaults
@@ -87,20 +91,20 @@ withGridLine t m = do
 
 -- | format the axis ticks
 setTicks :: Tick -> TickValues -> Axis ()
-setTicks Minor (TickNumber 0) = modify $ \s -> 
+setTicks Minor (TickNumber 0) = modify $ \s ->
   changeMinorTicks (const Nothing) s
-setTicks Minor ts             = modify $ \s -> 
+setTicks Minor ts             = modify $ \s ->
   changeMinorTicks (setTickValues ts) s
-setTicks Major (TickNumber 0) = modify $ \s -> 
+setTicks Major (TickNumber 0) = modify $ \s ->
   changeMajorTicks (const Nothing) s
-setTicks Major ts             = modify $ \s -> 
+setTicks Major ts             = modify $ \s ->
   changeMajorTicks (setTickValues ts) s
 
 -- | should gridlines be displayed?
 setGridlines :: Tick -> GridLines -> Axis ()
-setGridlines Minor gl = modify $ \s -> 
+setGridlines Minor gl = modify $ \s ->
   changeMinorTicks (setTickGridlines (if gl then defaultGridLine else NoLine)) s
-setGridlines Major gl = modify $ \s -> 
+setGridlines Major gl = modify $ \s ->
   changeMajorTicks (setTickGridlines (if gl then defaultGridLine else NoLine)) s
 
 -- | set the tick label format
@@ -109,7 +113,7 @@ setTickLabelFormat tf = modify $ \s -> changeTickFormat tf s
 
 -- | a list of data labels
 setTickLabels :: [String] -> Axis ()
-setTickLabels dl = modify $ \s -> 
+setTickLabels dl = modify $ \s ->
   changeTickLabels (const (map BareText dl)) s
 
 -- | format the tick labels
@@ -124,7 +128,7 @@ withAxisLabel :: Text () -> Axis ()
 withAxisLabel m = do
   ax <- get
   to <- asks _textoptions
-  put $ ax { _label = execText m to (_label ax) } 
+  put $ ax { _label = execText m to (_label ax) }
 
 -----------------------------------------------------------------------------
 
@@ -137,4 +141,3 @@ withTickLabelFormat m = do
   put $ ax { _tick_labels = map (execText m to) (_tick_labels ax) }
 
 -----------------------------------------------------------------------------
-

--- a/lib/Graphics/Rendering/Plot/Render/Plot.hs
+++ b/lib/Graphics/Rendering/Plot/Render/Plot.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Graphics.Rendering.Plot.Render.Plot
@@ -60,6 +61,10 @@ import Graphics.Rendering.Plot.Render.Plot.Annotation
 --import Prelude hiding(min,max)
 --import qualified Prelude(max)
 
+#if MIN_VERSION_mtl(2,3,0)
+import Control.Monad
+#endif
+
 -----------------------------------------------------------------------------
 
 bbPlot :: Int -> Int -> (Int,Int) -> Render ()
@@ -109,7 +114,7 @@ renderPlot (Plot b c p hd r a bc sd d l an) = do
   cairo C.save
   axes
   cairo C.restore
-  
+
 renderBorder :: Border -> Render ()
 renderBorder False = return ()
 renderBorder True  = do
@@ -118,7 +123,5 @@ renderBorder True  = do
     C.setLineWidth 0.5
     C.rectangle (x+0.5) (y+0.5) w h
     C.stroke
-                                           
+
 -----------------------------------------------------------------------------
-
-

--- a/lib/Graphics/Rendering/Plot/Render/Plot/Annotation.hs
+++ b/lib/Graphics/Rendering/Plot/Render/Plot/Annotation.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Graphics.Rendering.Plot.Render.Plot.Annotation
@@ -37,6 +38,10 @@ import Graphics.Rendering.Plot.Render.Plot.Format
 --import Prelude hiding(min,max)
 --import qualified Prelude(max)
 
+#if MIN_VERSION_mtl(2,3,0)
+import Control.Monad
+#endif
+
 -----------------------------------------------------------------------------
 
 renderAnnotations :: Ranges -> Annotations -> Render ()
@@ -44,13 +49,13 @@ renderAnnotations r an = do
   (BoundingBox x y w h) <- get
   let (xsc,xmin',xmax') = getRanges XAxis Lower r
   let (xmin,xmax) = if xsc == Log then (logBase 10 xmin',logBase 10 xmax') else (xmin',xmax')
-  let xscale = w/(xmax-xmin) 
+  let xscale = w/(xmax-xmin)
   cairo $ C.save
   let (yscl,yminl',ymaxl') = getRanges YAxis Lower r
   let (yminl,ymaxl) = if yscl == Log then (logBase 10 yminl',logBase 10 ymaxl') else (yminl',ymaxl')
-  let yscalel = h/(ymaxl-yminl) 
+  let yscalel = h/(ymaxl-yminl)
   -- transform to data coordinates
-  cairo $ do 
+  cairo $ do
     C.translate x (y+h)
     --C.scale xscale yscalel
     C.translate (-xmin*xscale) (yminl*yscalel)

--- a/lib/Graphics/Rendering/Plot/Render/Plot/Axis.hs
+++ b/lib/Graphics/Rendering/Plot/Render/Plot/Axis.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Graphics.Rendering.Plot.Render.Plot.Axis
@@ -25,7 +26,7 @@ module Graphics.Rendering.Plot.Render.Plot.Axis (
 
 import Data.Either
 
-import Data.List 
+import Data.List
 
 import Numeric.LinearAlgebra.Data hiding (Range)
 
@@ -47,6 +48,10 @@ import qualified Text.Printf as Printf
 
 import Prelude hiding(min,max)
 import qualified Prelude(max)
+
+#if MIN_VERSION_mtl(2,3,0)
+import Control.Monad
+#endif
 
 -----------------------------------------------------------------------------
 
@@ -135,7 +140,7 @@ shiftForAxisLabel p (Axis ax sd  _ _ _ _ _ lb) = do
       YAxis -> do
         (_,((w',h'))) <- textSizeVertical lo Centre Middle 0 0
         return (h',w')
-  shiftForAxisLabel' p ax sd w h 
+  shiftForAxisLabel' p ax sd w h
    where shiftForAxisLabel' (Padding l r b t) XAxis (Side Lower) _  h' = do
            bbRaiseBottom (h'+2*textPad)
            return $ Padding l r (b+h'+2*textPad) t
@@ -177,38 +182,38 @@ renderAxisLabel _ (Axis _     (Value _)    _ _ _ _ _ _ ) = return ()
 
 shiftForTicks :: Ranges -> Padding -> AxisData -> Render Padding
 shiftForTicks (Ranges (Left (Range _ xmin xmax)) _)
-                  p (Axis XAxis (Side Lower) _ min maj tf dl _) 
-   = shiftForTicks' p min maj XAxis (Side Lower) tf dl 
+                  p (Axis XAxis (Side Lower) _ min maj tf dl _)
+   = shiftForTicks' p min maj XAxis (Side Lower) tf dl
        (negate $ Prelude.max (abs xmin) (abs xmax))
 shiftForTicks (Ranges (Left (Range _ xmin xmax)) _)
-                  p (Axis XAxis (Side Upper) _ min maj tf dl _) 
-   = shiftForTicks' p min maj XAxis (Side Upper) tf dl 
+                  p (Axis XAxis (Side Upper) _ min maj tf dl _)
+   = shiftForTicks' p min maj XAxis (Side Upper) tf dl
        (negate $ Prelude.max (abs xmin) (abs xmax))
 shiftForTicks (Ranges (Right ((Range _ xmin xmax),_)) _)
-                  p (Axis XAxis (Side Lower) _ min maj tf dl _) 
-   = shiftForTicks' p min maj XAxis (Side Lower) tf dl 
+                  p (Axis XAxis (Side Lower) _ min maj tf dl _)
+   = shiftForTicks' p min maj XAxis (Side Lower) tf dl
        (negate $ Prelude.max (abs xmin) (abs xmax))
 shiftForTicks (Ranges (Right (_,(Range _ xmin xmax))) _)
-                  p (Axis XAxis (Side Upper) _ min maj tf dl _) 
-   = shiftForTicks' p min maj XAxis (Side Upper) tf dl 
+                  p (Axis XAxis (Side Upper) _ min maj tf dl _)
+   = shiftForTicks' p min maj XAxis (Side Upper) tf dl
        (negate $ Prelude.max (abs xmin) (abs xmax))
 shiftForTicks (Ranges _ (Left (Range _ ymin ymax)))
-                  p (Axis YAxis (Side Lower) _ min maj tf dl _) 
-   = shiftForTicks' p min maj YAxis (Side Lower) tf dl 
+                  p (Axis YAxis (Side Lower) _ min maj tf dl _)
+   = shiftForTicks' p min maj YAxis (Side Lower) tf dl
        (negate $ Prelude.max (abs ymin) (abs ymax))
 shiftForTicks (Ranges _ (Left (Range _ ymin ymax)))
-                  p (Axis YAxis (Side Upper) _ min maj tf dl _) 
-   = shiftForTicks' p min maj YAxis (Side Upper) tf dl 
+                  p (Axis YAxis (Side Upper) _ min maj tf dl _)
+   = shiftForTicks' p min maj YAxis (Side Upper) tf dl
        (negate $ Prelude.max (abs ymin) (abs ymax))
 shiftForTicks (Ranges _ (Right ((Range _ ymin ymax),_)))
-                  p (Axis YAxis (Side Lower) _ min maj tf dl _) 
-   = shiftForTicks' p min maj YAxis (Side Lower) tf dl 
+                  p (Axis YAxis (Side Lower) _ min maj tf dl _)
+   = shiftForTicks' p min maj YAxis (Side Lower) tf dl
        (negate $ Prelude.max (abs ymin) (abs ymax))
 shiftForTicks (Ranges _ (Right (_,(Range _ ymin ymax))))
-                  p (Axis YAxis (Side Upper) _ min maj tf dl _) 
-   = shiftForTicks' p min maj YAxis (Side Upper) tf dl 
+                  p (Axis YAxis (Side Upper) _ min maj tf dl _)
+   = shiftForTicks' p min maj YAxis (Side Upper) tf dl
        (negate $ Prelude.max (abs ymin) (abs ymax))
-shiftForTicks _ p (Axis _ (Value _) _ _ _ _ _ _) 
+shiftForTicks _ p (Axis _ (Value _) _ _ _ _ _ _)
    = return p
 
 shiftForTicks' :: Padding -> Maybe Ticks -> Maybe Ticks -> AxisType -> AxisPosn -> TickFormat -> [TextEntry] -> Double -> Render Padding
@@ -222,7 +227,7 @@ shiftForTicks' p _                  (Just (Ticks _ _)) ax    sd           tf dl 
          s' = if null dl then s else case head dl of
             NoText          -> error "NoText as a datalabel"
             BareText bt     -> bt
-            SizeText _ _ st -> st 
+            SizeText _ _ st -> st
             FontText _ ft   -> ft
      lt <- pango $ P.layoutText pc s'
      setTextOptions (scaleFontSize tickLabelScale to) lt
@@ -259,9 +264,9 @@ shiftForTicks' (Padding l r b t) (Ticks _ (Left _)) (Ticks _ (Left 0)) YAxis (Si
 -}
 
 renderAxis :: Ranges -> AxisData -> Render ()
-renderAxis _ (Axis _ _ NoLine _ _ _ _ _) = return () 
-renderAxis r (Axis ax sd 
-             (ColourLine c) 
+renderAxis _ (Axis _ _ NoLine _ _ _ _ _) = return ()
+renderAxis r (Axis ax sd
+             (ColourLine c)
              min maj tf dl l) = do
   lo <- asks (_lineoptions . _renderoptions)
   renderAxis r (Axis ax sd (TypeLine lo c) min maj tf dl l)
@@ -278,7 +283,7 @@ lowerRange (Right (r@(Range _ _ _),_)) = r
 
 renderAxisLine :: Ranges -> AxisType -> AxisPosn -> Render ()
 renderAxisLine (Ranges _ yr) XAxis (Value v) = do
-  let (Range _ min max) = lowerRange yr                          
+  let (Range _ min max) = lowerRange yr
   (BoundingBox x y w h) <- get
   cairo $ do
     lw' <- C.getLineWidth
@@ -287,7 +292,7 @@ renderAxisLine (Ranges _ yr) XAxis (Value v) = do
     lineTo (x+w+lw) (y+h*((max-v)/(max-min)))
     C.stroke
 renderAxisLine (Ranges xr _) YAxis (Value v) = do
-  let (Range _ min max) = lowerRange xr                          
+  let (Range _ min max) = lowerRange xr
   (BoundingBox x y w h) <- get
   cairo $ do
     lw' <- C.getLineWidth
@@ -329,7 +334,7 @@ renderAxisLine _ YAxis (Side Upper) = do
     C.stroke
 
 tickPosition :: Tick -> Scale -> Double -> Double -> Either Int [Double] -> [(Double,Double)]
-tickPosition _ sc min max nv = 
+tickPosition _ sc min max nv =
   let ticks = either (\n -> take n [(0::Double)..]) id nv
       l = fromIntegral $ length ticks - 1
       pos = case nv of
@@ -367,7 +372,7 @@ renderAxisTicks (Ranges xrange yrange) ax sd tmn tmj tf dl = do
                              (Right (_,Range scl xmin xmax)) -> (scl,xmin,xmax)
                        (Value _)    -> case xrange of
                              (Left (Range scl xmin xmax))    -> (scl,xmin,xmax)
-                             (Right (Range scl xmin xmax,_)) -> (scl,xmin,xmax) 
+                             (Right (Range scl xmin xmax,_)) -> (scl,xmin,xmax)
                    YAxis -> case sd of
                        (Side Lower) -> case yrange of
                              (Left (Range scl ymin ymax))    -> (scl,ymin,ymax)
@@ -382,31 +387,31 @@ renderAxisTicks (Ranges xrange yrange) ax sd tmn tmj tf dl = do
               let sd' = case sd of
                           (Side _)  -> sd
                           (Value v) -> case ax of
-                                        XAxis -> let (Range _ b t) = 
+                                        XAxis -> let (Range _ b t) =
                                                         lowerRange yrange
                                                 in Value (y+h*(t-v)/(t-b))
-                                        YAxis -> let (Range _ b t) = 
+                                        YAxis -> let (Range _ b t) =
                                                         lowerRange xrange
                                                 in Value (x+w*(v-b)/(t-b))
-              let renderAxisTick' = renderAxisTick pc to x y w h 
-                                      sc min max ax sd' tf 
+              let renderAxisTick' = renderAxisTick pc to x y w h
+                                      sc min max ax sd' tf
               (majpos',gmaj',tjpos,tmaj') <- case tmj of
                 (Just (Ticks gmaj (TickNumber tmaj))) -> do
-                    let (pos,val) = unzip (tickPosition Major sc min max 
-                                             (Left tmaj))    
+                    let (pos,val) = unzip (tickPosition Major sc min max
+                                             (Left tmaj))
                     let ln = length pos
-                    let dl' = if null dl 
-                              then replicate ln Nothing 
+                    let dl' = if null dl
+                              then replicate ln Nothing
                               else map Just dl
                     let majpos = let ones = 1.0 : ones
                                  in zip4 pos (take ln ones) val dl'
                     return $ (Just majpos,Just gmaj,Just pos,Just tmaj)
                 (Just (Ticks gmaj (TickValues tmaj))) -> do
-                    let (pos,val) = unzip (tickPosition Major sc min max 
+                    let (pos,val) = unzip (tickPosition Major sc min max
                                              (Right $ toList tmaj))
                         ln = length pos
-                    let dl' = if null dl 
-                              then replicate ln Nothing 
+                    let dl' = if null dl
+                              then replicate ln Nothing
                               else map Just dl
                     let majpos = let ones = 1.0 : ones
                                  in zip4 pos (take ln ones) val dl'
@@ -414,31 +419,31 @@ renderAxisTicks (Ranges xrange yrange) ax sd tmn tmj tf dl = do
                 Nothing -> return (Nothing,Nothing,Nothing,Nothing)
               (minpos',gmin') <- case tmn of
                 (Just (Ticks gmin (TickNumber tmin))) -> do
-                    let (pos',val') = unzip (tickPosition Minor sc min max 
+                    let (pos',val') = unzip (tickPosition Minor sc min max
                                                (Left tmin))
                         ln' = length pos'
-                        minpos' = zip4 pos' (minorTickLengths tmin 
-                                               (maybe 0 id tmaj')) val' 
+                        minpos' = zip4 pos' (minorTickLengths tmin
+                                               (maybe 0 id tmaj')) val'
                                      (replicate ln' Nothing)
-                        minpos = filter (not . (\(p,_,_,_) -> 
+                        minpos = filter (not . (\(p,_,_,_) ->
                                    elem p (maybe [] id tjpos))) minpos'
                     return $ (Just minpos,Just gmin)
                 (Just (Ticks gmin (TickValues tmin))) -> do
-                    let (pos,val) = unzip (tickPosition Minor sc min max 
+                    let (pos,val) = unzip (tickPosition Minor sc min max
                                              (Right $ toList tmin))
                         ln = length pos
                         minpos' = let halves = 0.7 : halves
                                  in zip4 pos halves pos (replicate ln Nothing)
-                        minpos = filter (not . (\(p,_,_,_) -> 
+                        minpos = filter (not . (\(p,_,_,_) ->
                                    elem p (maybe [] id tjpos))) minpos'
                     return $ (Just minpos,Just gmin)
                 Nothing -> return (Nothing,Nothing)
               case majpos' of
-                (Just m) -> mapM_ (renderAxisTick' Major 
+                (Just m) -> mapM_ (renderAxisTick' Major
                                     (maybe NoLine id gmaj')) m
                 Nothing  -> return ()
               case minpos' of
-                (Just m) -> mapM_ (renderAxisTick' Minor 
+                (Just m) -> mapM_ (renderAxisTick' Minor
                                     (maybe NoLine id gmin')) m
                 Nothing  -> return ()
               return ()
@@ -449,7 +454,7 @@ minorTickLengths min maj = let num = (min-1) `div` (maj-1)
                            in map ((/ 2) . (+ 1) . (* 2) . (/ (fromIntegral num)) . fromIntegral . (\x -> if x > (num `div` 2) then num - x else x) . (`mod` num)) (take (min+1) [0..])
                    --map ((/) 2 . (+) 1 . (/) (fromIntegral tmaj) . fromIntegral . (mod tmaj)) (take (tmin+1) [0..])
 
-renderAxisTick :: P.PangoContext -> TextOptions 
+renderAxisTick :: P.PangoContext -> TextOptions
                -> Double -> Double -> Double -> Double -> Scale -> Double -> Double
                -> AxisType -> AxisPosn -> TickFormat -> Tick -> LineType
                -> (Double,Double,Double,Maybe TextEntry) -> C.Render ()
@@ -493,12 +498,12 @@ renderAxisTick pc to x y w h sc min max xa sd tf t gl (p,l,v,dl) = do
                                          (Value _)    -> let yt y' = (y + h) - (y'-min)*h/(max-min)
                                                         in (x,yt p,x+w,yt p)
          C.save
-         setLineStyle gl             
+         setLineStyle gl
          moveTo x3 y3
          lineTo x4 y4
          C.stroke
          C.restore)
-       let majlab = case sd of 
+       let majlab = case sd of
                       (Side _)  -> True
                       (Value _) -> False
        when (t == Major && majlab) $ do
@@ -513,7 +518,7 @@ renderAxisTick pc to x y w h sc min max xa sd tf t gl (p,l,v,dl) = do
                         FontText _ ft -> ft
             lo <- pango $ P.layoutText pc s''
             setTextOptions (scaleFontSize tickLabelScale to) lo
-            case xa of 
+            case xa of
               XAxis -> do
                 case sd of
                   (Side Lower) -> do

--- a/lib/Graphics/Rendering/Plot/Render/Plot/Legend.hs
+++ b/lib/Graphics/Rendering/Plot/Render/Plot/Legend.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Graphics.Rendering.Plot.Render.Plot.Legend
@@ -41,6 +42,10 @@ import Graphics.Rendering.Plot.Render.Plot.Glyph
 --import Prelude hiding(min,max)
 --import qualified Prelude(max)
 
+#if MIN_VERSION_mtl(2,3,0)
+import Control.Monad
+#endif
+
 -----------------------------------------------------------------------------
 
 renderLegend :: Maybe LegendData -> DataSeries -> Render (Padding -> Render ())
@@ -53,7 +58,7 @@ renderLegend (Just (Legend b l o to)) d = do
   (w,h) <- cairo $ do
      lo <- pango $ P.layoutText pc mx
      setTextOptions to lo
-     (_,twh) <- textSize lo Centre Middle 0 0 
+     (_,twh) <- textSize lo Centre Middle 0 0
      return twh
   -- if outside shift bounding box
   case o of
@@ -65,21 +70,21 @@ renderLegend (Just (Legend b l o to)) d = do
     Inside ->  return $ \_ -> renderLegendInside b l w h to ln ls
 
 renderLegendOutside :: Bool -> LegendLocation -> Double -> Double -> TextOptions -> Int -> [(SeriesLabel,Decoration)] -> Render (Padding -> Render ())
-renderLegendOutside b l w h to ln ls 
+renderLegendOutside b l w h to ln ls
     | l == North                 = do
        let h' = textPad + h + textPad
        bbLowerTop $ h' + 4*textPad
        return $ \(Padding _ _ _ t) -> do
           x' <- bbCentreWidth
           y' <- bbTopHeight
-          let w' = (fromIntegral ln)*(textPad + legendSampleWidth 
+          let w' = (fromIntegral ln)*(textPad + legendSampleWidth
                     + legendSampleWidth + textPad + w) + 5*textPad
           let x = x'- (w'/2)
               y = y'- h' - t
           when b (cairo $ renderBorder 1.0 black (x+0.5) (y+0.5) w' h')
-          renderLegendEntries (x+3*textPad) (y+textPad) 
-            (textPad + legendSampleWidth + legendSampleWidth + textPad 
-                     + w + textPad) 0 0 h to ls 
+          renderLegendEntries (x+3*textPad) (y+textPad)
+            (textPad + legendSampleWidth + legendSampleWidth + textPad
+                     + w + textPad) 0 0 h to ls
           return ()
     | l == NorthEast             = do
        let h' = textPad + h + textPad
@@ -87,17 +92,17 @@ renderLegendOutside b l w h to ln ls
        return $ \(Padding _ _ _ t) -> do
           x' <- bbRightWidth
           y' <- bbTopHeight
-          let w' = (fromIntegral ln)*(textPad + legendSampleWidth 
+          let w' = (fromIntegral ln)*(textPad + legendSampleWidth
                     + legendSampleWidth + textPad + w) + 5*textPad
           let x = x'- w'
               y = y'- h' - t
           when b (cairo $ renderBorder 1.0 black (x+0.5) (y+0.5) w' h')
-          renderLegendEntries (x+3*textPad) (y+textPad) 
-            (textPad + legendSampleWidth + legendSampleWidth + textPad 
-                     + w + textPad) 0 0 h to ls 
+          renderLegendEntries (x+3*textPad) (y+textPad)
+            (textPad + legendSampleWidth + legendSampleWidth + textPad
+                     + w + textPad) 0 0 h to ls
           return ()
     | l == East                  = do
-       let w' = textPad + legendSampleWidth + legendSampleWidth 
+       let w' = textPad + legendSampleWidth + legendSampleWidth
                         + textPad + w + textPad
        bbShiftRight $ w' + 4*textPad
        return $ \(Padding _ r _ _) -> do
@@ -107,8 +112,8 @@ renderLegendOutside b l w h to ln ls
           let x = x' + 4*textPad + r
               y = y'-(h'/2)
           when b (cairo $ renderBorder 1.0 black (x+0.5) (y+0.5) w' h')
-          renderLegendEntries (x+2*textPad) (y+3*textPad) 0 (h+textPad) 
-             0 h to ls 
+          renderLegendEntries (x+2*textPad) (y+3*textPad) 0 (h+textPad)
+             0 h to ls
           return ()
     | l == SouthEast             = do
        let h' = textPad + h + textPad
@@ -116,14 +121,14 @@ renderLegendOutside b l w h to ln ls
        return $ \(Padding _ _ b' _) -> do
           x' <- bbRightWidth
           y' <- bbBottomHeight
-          let w' = (fromIntegral ln)*(textPad + legendSampleWidth 
+          let w' = (fromIntegral ln)*(textPad + legendSampleWidth
                      + legendSampleWidth + textPad + w) + 5*textPad
           let x = x'- w'
               y = y' + b' +textPad
           when b (cairo $ renderBorder 1.0 black (x+0.5) (y+0.5) w' h')
-          renderLegendEntries (x+3*textPad) (y+textPad) 
-            (textPad + legendSampleWidth + legendSampleWidth + textPad 
-                     + w + textPad) 0 0 h to ls 
+          renderLegendEntries (x+3*textPad) (y+textPad)
+            (textPad + legendSampleWidth + legendSampleWidth + textPad
+                     + w + textPad) 0 0 h to ls
           return ()
     | l == South                 = do
        let h' = textPad + h + textPad
@@ -131,14 +136,14 @@ renderLegendOutside b l w h to ln ls
        return $ \(Padding _ _ b' _) -> do
           x' <- bbCentreWidth
           y' <- bbBottomHeight
-          let w' = (fromIntegral ln)*(textPad + legendSampleWidth 
+          let w' = (fromIntegral ln)*(textPad + legendSampleWidth
                      + legendSampleWidth + textPad + w) + 5*textPad
           let x = x' - (w'/2)
               y = y' + b' +textPad
           when b (cairo $ renderBorder 1.0 black (x+0.5) (y+0.5) w' h')
-          renderLegendEntries (x+3*textPad) (y+textPad) 
-            (textPad + legendSampleWidth + legendSampleWidth + textPad 
-                     + w + textPad) 0 0 h to ls 
+          renderLegendEntries (x+3*textPad) (y+textPad)
+            (textPad + legendSampleWidth + legendSampleWidth + textPad
+                     + w + textPad) 0 0 h to ls
           return ()
     | l == SouthWest             = do
        let h' = textPad + h + textPad
@@ -146,17 +151,17 @@ renderLegendOutside b l w h to ln ls
        return $ \(Padding _ _ b' _) -> do
           x' <- bbLeftWidth
           y' <- bbBottomHeight
-          let w' = (fromIntegral ln)*(textPad + legendSampleWidth 
+          let w' = (fromIntegral ln)*(textPad + legendSampleWidth
                      + legendSampleWidth + textPad + w) + 5*textPad
           let x = x'
               y = y' + b' +textPad
           when b (cairo $ renderBorder 1.0 black (x+0.5) (y+0.5) w' h')
-          renderLegendEntries (x+3*textPad) (y+textPad) 
-             (textPad + legendSampleWidth + legendSampleWidth + textPad 
-                      + w + textPad) 0 0 h to ls 
+          renderLegendEntries (x+3*textPad) (y+textPad)
+             (textPad + legendSampleWidth + legendSampleWidth + textPad
+                      + w + textPad) 0 0 h to ls
           return ()
     | l == West                   = do
-       let w' = textPad + legendSampleWidth + legendSampleWidth + textPad 
+       let w' = textPad + legendSampleWidth + legendSampleWidth + textPad
                         + w + textPad
        bbShiftLeft $ w' + 4*textPad
        return $ \(Padding l' _ _ _) -> do
@@ -166,8 +171,8 @@ renderLegendOutside b l w h to ln ls
           let x = x' - w' - 4*textPad - l'
               y = y'-(h'/2)
           when b (cairo $ renderBorder 1.0 black (x+0.5) (y+0.5) w' h')
-          renderLegendEntries (x+2*textPad) (y+3*textPad) 0 (h+textPad) 
-            0 h to ls 
+          renderLegendEntries (x+2*textPad) (y+3*textPad) 0 (h+textPad)
+            0 h to ls
           return ()
     | l == NorthWest             = do
        let h' = textPad + h + textPad
@@ -175,14 +180,14 @@ renderLegendOutside b l w h to ln ls
        return $ \(Padding _ _ _ t) -> do
           x' <- bbLeftWidth
           y' <- bbTopHeight
-          let w' = (fromIntegral ln)*(textPad + legendSampleWidth 
+          let w' = (fromIntegral ln)*(textPad + legendSampleWidth
                      + legendSampleWidth + textPad + w) + 5*textPad
           let x = x'
               y = y'- h' - t
           when b (cairo $ renderBorder 1.0 black (x+0.5) (y+0.5) w' h')
-          renderLegendEntries (x+3*textPad) (y+textPad) 
-            (textPad + legendSampleWidth + legendSampleWidth + textPad 
-                     + w + textPad) 0 0 h to ls 
+          renderLegendEntries (x+3*textPad) (y+textPad)
+            (textPad + legendSampleWidth + legendSampleWidth + textPad
+                     + w + textPad) 0 0 h to ls
           return ()
 renderLegendOutside _ _ _ _ _ _ _ = return (\_ -> return ())
 
@@ -195,7 +200,7 @@ renderBorder lw c x y w h = do
 
 renderLegendInside :: Bool -> LegendLocation -> Double -> Double -> TextOptions -> Int -> [(SeriesLabel,Decoration)] -> Render ()
 renderLegendInside b l w h to ln ls = do
-  let w' = (textPad + legendSampleWidth + legendSampleWidth + textPad 
+  let w' = (textPad + legendSampleWidth + legendSampleWidth + textPad
                     + w + textPad)
       h' = h+textPad
       h'' = (fromIntegral ln)*h'+textPad
@@ -211,7 +216,7 @@ renderLegendInside b l w h to ln ls = do
      East      -> do
        x' <- bbRightWidth
        y' <- bbCentreHeight
-       let y'' = y' - h''/2 
+       let y'' = y' - h''/2
        return (x'-w'-3*textPad,y''-textPad)
      SouthEast -> do
        x' <- bbRightWidth
@@ -231,7 +236,7 @@ renderLegendInside b l w h to ln ls = do
      West      -> do
        x' <- bbLeftWidth
        y' <- bbCentreHeight
-       let y'' = y' - h''/2 
+       let y'' = y' - h''/2
        return (x'+textPad,y''-textPad)
      NorthWest -> do
        x' <- bbLeftWidth
@@ -244,10 +249,10 @@ renderLegendInside b l w h to ln ls = do
     C.rectangle (x+0.5) (y+0.5) w' h''
     C.fill
     C.stroke
-  renderLegendEntries (x+3*textPad) (y+textPad) 0 h' w' 
-           (h'-textPad) to ls 
+  renderLegendEntries (x+3*textPad) (y+textPad) 0 h' w'
+           (h'-textPad) to ls
 
-renderLegendEntries :: Double -> Double -> Double -> Double -> Double -> Double 
+renderLegendEntries :: Double -> Double -> Double -> Double -> Double -> Double
                     -> TextOptions
                     -> [(SeriesLabel,Decoration)] -> Render ()
 renderLegendEntries x y wa ha w h to ls = do
@@ -280,7 +285,7 @@ renderLegendSample x y w h d = do
     Nothing -> return ()
     Just p' -> do
       cairo $ do
-        C.save   
+        C.save
         C.moveTo (x+w/2) (y+h/2)
         g <- setPointStyle p'
         renderGlyph 1 g
@@ -301,4 +306,3 @@ getLabels (DS_1to1 d)   = let mls = map (\(_,(DecSeries o d')) -> (maybe "" id $
 getLabels (DS_Surf _)   = (0,[])
 
 -----------------------------------------------------------------------------
-


### PR DESCRIPTION
mtl-2.3 stopped re-exporting `Control.Monad`, so I added it conditionally in the files that needed it.